### PR TITLE
Add light/dark theme switcher with full site-wide support

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -20,13 +20,13 @@ export default function AboutPage() {
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div className="mb-12">
-        <p className="text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
+        <p className="text-brand-500 dark:text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
           About me
         </p>
-        <h1 className="text-4xl font-bold text-white mb-4">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
           Engineer. Creator. Builder.
         </h1>
-        <p className="text-gray-400 text-lg leading-relaxed max-w-2xl">
+        <p className="text-gray-600 dark:text-gray-400 text-lg leading-relaxed max-w-2xl">
           I&apos;m Siavash — a software engineer with over a decade of experience
           building systems that scale, teams that ship, and products that matter.
         </p>
@@ -37,11 +37,11 @@ export default function AboutPage() {
         {facts.map(({ icon: Icon, label, value }) => (
           <div
             key={label}
-            className="rounded-xl border border-white/5 bg-white/2 p-4"
+            className="rounded-xl border border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-white/5 p-4"
           >
-            <Icon size={16} className="text-brand-400 mb-2" />
-            <p className="text-xs text-gray-600 mb-1">{label}</p>
-            <p className="text-sm font-medium text-white">{value}</p>
+            <Icon size={16} className="text-brand-500 dark:text-brand-400 mb-2" />
+            <p className="text-xs text-gray-500 dark:text-gray-600 mb-1">{label}</p>
+            <p className="text-sm font-medium text-gray-900 dark:text-white">{value}</p>
           </div>
         ))}
       </div>
@@ -49,10 +49,10 @@ export default function AboutPage() {
       <div className="prose-custom space-y-10">
         {/* Origin story */}
         <section>
-          <h2 className="text-2xl font-semibold text-white mb-4">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
             The origin story
           </h2>
-          <div className="space-y-4 text-gray-400 leading-relaxed">
+          <div className="space-y-4 text-gray-600 dark:text-gray-400 leading-relaxed">
             <p>
               I grew up in Tehran, Iran, where I fell in love with computers as a
               teenager — taking apart hardware, learning to code, and spending more
@@ -74,10 +74,10 @@ export default function AboutPage() {
 
         {/* Engineering */}
         <section>
-          <h2 className="text-2xl font-semibold text-white mb-4">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
             The engineering chapter
           </h2>
-          <div className="space-y-4 text-gray-400 leading-relaxed">
+          <div className="space-y-4 text-gray-600 dark:text-gray-400 leading-relaxed">
             <p>
               Over the past decade, I&apos;ve worked across fintech, e-commerce, and
               SaaS — building everything from payment infrastructure to real-time
@@ -98,10 +98,10 @@ export default function AboutPage() {
 
         {/* YouTube */}
         <section>
-          <h2 className="text-2xl font-semibold text-white mb-4">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
             Why SiaExplains?
           </h2>
-          <div className="space-y-4 text-gray-400 leading-relaxed">
+          <div className="space-y-4 text-gray-600 dark:text-gray-400 leading-relaxed">
             <p>
               I started SiaExplains because I wanted to create the content I
               wished existed when I was earlier in my career. Content that respects
@@ -118,10 +118,10 @@ export default function AboutPage() {
 
         {/* Personal */}
         <section>
-          <h2 className="text-2xl font-semibold text-white mb-4">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">
             Outside the terminal
           </h2>
-          <div className="space-y-4 text-gray-400 leading-relaxed">
+          <div className="space-y-4 text-gray-600 dark:text-gray-400 leading-relaxed">
             <p>
               When I&apos;m not building software, I&apos;m probably reading, doing strength
               training, or exploring Berlin&apos;s surprisingly great coffee scene. I&apos;m
@@ -136,7 +136,7 @@ export default function AboutPage() {
       </div>
 
       {/* CTA */}
-      <div className="mt-14 pt-8 border-t border-white/5 flex flex-wrap gap-4">
+      <div className="mt-14 pt-8 border-t border-gray-200 dark:border-white/5 flex flex-wrap gap-4">
         <Link
           href="/timeline"
           className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-brand-600 hover:bg-brand-500 text-white font-medium transition-colors text-sm"
@@ -145,13 +145,13 @@ export default function AboutPage() {
         </Link>
         <Link
           href="/cv"
-          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-white/10 hover:bg-white/5 text-gray-300 font-medium transition-colors text-sm"
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-gray-300 dark:border-white/10 hover:bg-gray-100 dark:hover:bg-white/5 text-gray-700 dark:text-gray-300 font-medium transition-colors text-sm"
         >
           View CV
         </Link>
         <Link
           href="/contact"
-          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-white/10 hover:bg-white/5 text-gray-300 font-medium transition-colors text-sm"
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-gray-300 dark:border-white/10 hover:bg-gray-100 dark:hover:bg-white/5 text-gray-700 dark:text-gray-300 font-medium transition-colors text-sm"
         >
           Get in touch
         </Link>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -16,22 +16,22 @@ export default function BlogPage() {
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div className="mb-12">
-        <p className="text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
+        <p className="text-brand-500 dark:text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
           Writing
         </p>
-        <h1 className="text-4xl font-bold text-white mb-4">Blog</h1>
-        <p className="text-gray-400 text-lg">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">Blog</h1>
+        <p className="text-gray-600 dark:text-gray-400 text-lg">
           Thoughts on engineering, career, AI, and building software that lasts.
           Shorter form than articles — more personal, more frequent.
         </p>
       </div>
 
       {posts.length === 0 ? (
-        <div className="text-center py-20 text-gray-600">
+        <div className="text-center py-20 text-gray-500">
           <p>No posts yet. Check back soon.</p>
         </div>
       ) : (
-        <div className="divide-y divide-white/5">
+        <div className="divide-y divide-gray-200 dark:divide-white/5">
           {posts.map((post) => (
             <Link
               key={post.slug}
@@ -42,26 +42,26 @@ export default function BlogPage() {
                 {post.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="inline-flex items-center gap-1 text-xs text-gray-600 bg-white/3 px-2 py-0.5 rounded-full"
+                    className="inline-flex items-center gap-1 text-xs text-gray-500 bg-gray-100 dark:bg-white/5 px-2 py-0.5 rounded-full"
                   >
                     <Tag size={9} />
                     {tag}
                   </span>
                 ))}
               </div>
-              <h2 className="text-xl font-semibold text-gray-100 group-hover:text-white transition-colors mb-2">
+              <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100 group-hover:text-gray-900 dark:group-hover:text-white transition-colors mb-2">
                 {post.title}
               </h2>
               <p className="text-gray-500 leading-relaxed mb-3 text-sm">
                 {post.description}
               </p>
               <div className="flex items-center justify-between">
-                <div className="flex gap-3 text-xs text-gray-600">
+                <div className="flex gap-3 text-xs text-gray-500">
                   <span>{formatDate(post.date)}</span>
                   <span>·</span>
                   <span>{post.readingTime}</span>
                 </div>
-                <span className="text-xs text-brand-400 inline-flex items-center gap-1 group-hover:gap-2 transition-all">
+                <span className="text-xs text-brand-600 dark:text-brand-400 inline-flex items-center gap-1 group-hover:gap-2 transition-all">
                   Read <ArrowRight size={12} />
                 </span>
               </div>

--- a/app/books/page.tsx
+++ b/app/books/page.tsx
@@ -90,7 +90,7 @@ function StarRating({ rating }: { rating: number }) {
       {[1, 2, 3, 4, 5].map((star) => (
         <span
           key={star}
-          className={star <= rating ? "text-amber-400" : "text-gray-700"}
+          className={star <= rating ? "text-amber-500 dark:text-amber-400" : "text-gray-300 dark:text-gray-700"}
         >
           ★
         </span>
@@ -103,11 +103,11 @@ export default function BooksPage() {
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div className="mb-12">
-        <p className="text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
+        <p className="text-brand-500 dark:text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
           Reading list
         </p>
-        <h1 className="text-4xl font-bold text-white mb-4">Books</h1>
-        <p className="text-gray-400 text-lg">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">Books</h1>
+        <p className="text-gray-600 dark:text-gray-400 text-lg">
           Books that shaped how I think about engineering, leadership, and the
           world. Only ones I&apos;d actually recommend.
         </p>
@@ -115,13 +115,13 @@ export default function BooksPage() {
 
       {/* Category filters (static for now) */}
       <div className="flex flex-wrap gap-2 mb-10">
-        <span className="text-xs px-3 py-1 rounded-full bg-brand-500/10 border border-brand-500/20 text-brand-400">
+        <span className="text-xs px-3 py-1 rounded-full bg-brand-500/10 border border-brand-500/20 text-brand-600 dark:text-brand-400">
           All ({books.length})
         </span>
         {categories.map((cat) => (
           <span
             key={cat}
-            className="text-xs px-3 py-1 rounded-full bg-white/5 border border-white/5 text-gray-500"
+            className="text-xs px-3 py-1 rounded-full bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-white/5 text-gray-500"
           >
             {cat} ({books.filter((b) => b.category === cat).length})
           </span>
@@ -132,12 +132,12 @@ export default function BooksPage() {
         {books.map((book) => (
           <div
             key={book.title}
-            className="rounded-2xl border border-white/5 bg-white/2 p-5 hover:border-white/10 transition-colors"
+            className="rounded-2xl border border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-white/5 p-5 hover:border-gray-300 dark:hover:border-white/10 transition-colors"
           >
             <div className="flex items-start gap-3 mb-3">
               <span className="text-3xl shrink-0">{book.emoji}</span>
               <div className="flex-1 min-w-0">
-                <h3 className="font-semibold text-white text-sm leading-snug mb-0.5">
+                <h3 className="font-semibold text-gray-900 dark:text-white text-sm leading-snug mb-0.5">
                   {book.title}
                 </h3>
                 <p className="text-xs text-gray-500">{book.author}</p>
@@ -145,14 +145,14 @@ export default function BooksPage() {
             </div>
 
             <div className="flex items-center justify-between mb-3">
-              <span className="text-xs px-2 py-0.5 rounded-full bg-white/5 text-gray-500">
+              <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-white/5 text-gray-500">
                 {book.category}
               </span>
               <StarRating rating={book.rating} />
             </div>
 
             {book.notes && (
-              <p className="text-xs text-gray-500 leading-relaxed border-t border-white/5 pt-3">
+              <p className="text-xs text-gray-500 leading-relaxed border-t border-gray-200 dark:border-white/5 pt-3">
                 {book.notes}
               </p>
             )}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -14,7 +14,7 @@ const socials = [
     handle: "@SiaExplains",
     href: "https://youtube.com/@SiaExplains",
     icon: YoutubeIcon,
-    color: "text-rose-400",
+    color: "text-rose-500 dark:text-rose-400",
     bg: "bg-rose-500/10",
     border: "border-rose-500/20",
   },
@@ -23,16 +23,16 @@ const socials = [
     handle: "github.com/siavash",
     href: "https://github.com/siavash",
     icon: GithubIcon,
-    color: "text-gray-300",
-    bg: "bg-white/5",
-    border: "border-white/10",
+    color: "text-gray-600 dark:text-gray-300",
+    bg: "bg-gray-100 dark:bg-white/5",
+    border: "border-gray-200 dark:border-white/10",
   },
   {
     label: "LinkedIn",
     handle: "linkedin.com/in/siavash",
     href: "https://linkedin.com/in/siavash",
     icon: LinkedinIcon,
-    color: "text-sky-400",
+    color: "text-sky-600 dark:text-sky-400",
     bg: "bg-sky-500/10",
     border: "border-sky-500/20",
   },
@@ -41,9 +41,9 @@ const socials = [
     handle: "@SiaExplains",
     href: "https://twitter.com/SiaExplains",
     icon: TwitterIcon,
-    color: "text-gray-300",
-    bg: "bg-white/5",
-    border: "border-white/10",
+    color: "text-gray-600 dark:text-gray-300",
+    bg: "bg-gray-100 dark:bg-white/5",
+    border: "border-gray-200 dark:border-white/10",
   },
 ];
 
@@ -51,11 +51,11 @@ export default function ContactPage() {
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div className="mb-12">
-        <p className="text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
+        <p className="text-brand-500 dark:text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
           Get in touch
         </p>
-        <h1 className="text-4xl font-bold text-white mb-4">Contact</h1>
-        <p className="text-gray-400 text-lg leading-relaxed max-w-xl">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">Contact</h1>
+        <p className="text-gray-600 dark:text-gray-400 text-lg leading-relaxed max-w-xl">
           I&apos;m open to interesting conversations — collaborations, speaking
           invitations, feedback on my content, or just saying hello. I read
           everything, though I can&apos;t always reply quickly.
@@ -65,7 +65,7 @@ export default function ContactPage() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         {/* Contact form */}
         <div>
-          <h2 className="text-lg font-semibold text-white mb-5">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-5">
             Send a message
           </h2>
           <ContactForm />
@@ -73,7 +73,7 @@ export default function ContactPage() {
 
         {/* Socials */}
         <div>
-          <h2 className="text-lg font-semibold text-white mb-5">Find me on</h2>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-5">Find me on</h2>
           <div className="space-y-3">
             {socials.map(({ label, handle, href, icon: Icon, color, bg, border }) => (
               <a
@@ -81,23 +81,23 @@ export default function ContactPage() {
                 href={href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className={`flex items-center gap-3 p-4 rounded-xl border ${bg} ${border} hover:border-white/20 transition-colors`}
+                className={`flex items-center gap-3 p-4 rounded-xl border ${bg} ${border} hover:border-gray-300 dark:hover:border-white/20 transition-colors`}
               >
                 <div className={`p-2 rounded-lg ${bg}`}>
                   <Icon size={18} className={color} />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-white">{label}</p>
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">{label}</p>
                   <p className="text-xs text-gray-500">{handle}</p>
                 </div>
               </a>
             ))}
           </div>
 
-          <div className="mt-6 p-4 rounded-xl border border-white/5 bg-white/2">
+          <div className="mt-6 p-4 rounded-xl border border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-white/5">
             <div className="flex items-center gap-2 mb-1">
-              <Mail size={14} className="text-brand-400" />
-              <span className="text-sm font-medium text-white">Email</span>
+              <Mail size={14} className="text-brand-500 dark:text-brand-400" />
+              <span className="text-sm font-medium text-gray-900 dark:text-white">Email</span>
             </div>
             <p className="text-sm text-gray-500">siavash@siaexplains.com</p>
           </div>

--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -84,15 +84,15 @@ export default function CvPage() {
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       {/* Header */}
-      <div className="mb-12 pb-8 border-b border-white/5">
-        <h1 className="text-4xl font-bold text-white mb-2">Siavash</h1>
-        <p className="text-brand-400 text-lg mb-1">
+      <div className="mb-12 pb-8 border-b border-gray-200 dark:border-white/5">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-2">Siavash</h1>
+        <p className="text-brand-500 dark:text-brand-400 text-lg mb-1">
           Principal Software Engineer & Tech Lead
         </p>
         <p className="text-gray-500 text-sm">
           Berlin, Germany · siavash@siaexplains.com · SiaExplains.com
         </p>
-        <p className="mt-4 text-gray-400 leading-relaxed max-w-2xl">
+        <p className="mt-4 text-gray-600 dark:text-gray-400 leading-relaxed max-w-2xl">
           Principal engineer with 10+ years building high-scale distributed
           systems. Experienced in fintech, SaaS, and logistics. Passionate about
           clean architecture, engineering culture, and sharing knowledge.
@@ -101,7 +101,7 @@ export default function CvPage() {
 
       {/* Experience */}
       <section className="mb-12">
-        <div className="flex items-center gap-2 text-xs uppercase tracking-widest text-gray-600 mb-6">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-widest text-gray-500 dark:text-gray-600 mb-6">
           <Briefcase size={14} />
           Experience
         </div>
@@ -109,21 +109,21 @@ export default function CvPage() {
           {experience.map((job) => (
             <div
               key={`${job.company}-${job.period}`}
-              className="border-l-2 border-white/5 pl-5 hover:border-brand-500/40 transition-colors"
+              className="border-l-2 border-gray-200 dark:border-white/5 pl-5 hover:border-brand-500/40 transition-colors"
             >
               <div className="flex flex-wrap items-start justify-between gap-2 mb-2">
                 <div>
-                  <h3 className="font-semibold text-white">{job.role}</h3>
-                  <p className="text-brand-400 text-sm">{job.company}</p>
+                  <h3 className="font-semibold text-gray-900 dark:text-white">{job.role}</h3>
+                  <p className="text-brand-500 dark:text-brand-400 text-sm">{job.company}</p>
                 </div>
                 <div className="text-right">
                   <p className="text-sm text-gray-500">{job.period}</p>
-                  <p className="text-xs text-gray-600">{job.location}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-600">{job.location}</p>
                 </div>
               </div>
               <ul className="space-y-1 mt-3">
                 {job.bullets.map((b, i) => (
-                  <li key={i} className="text-sm text-gray-400 flex gap-2">
+                  <li key={i} className="text-sm text-gray-600 dark:text-gray-400 flex gap-2">
                     <span className="text-brand-500 mt-1 shrink-0">›</span>
                     {b}
                   </li>
@@ -136,21 +136,21 @@ export default function CvPage() {
 
       {/* Education */}
       <section className="mb-12">
-        <div className="flex items-center gap-2 text-xs uppercase tracking-widest text-gray-600 mb-6">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-widest text-gray-500 dark:text-gray-600 mb-6">
           <GraduationCap size={14} />
           Education
         </div>
         {education.map((edu) => (
-          <div key={edu.institution} className="border-l-2 border-white/5 pl-5">
+          <div key={edu.institution} className="border-l-2 border-gray-200 dark:border-white/5 pl-5">
             <div className="flex flex-wrap items-start justify-between gap-2 mb-1">
               <div>
-                <h3 className="font-semibold text-white">{edu.degree}</h3>
-                <p className="text-brand-400 text-sm">{edu.institution}</p>
+                <h3 className="font-semibold text-gray-900 dark:text-white">{edu.degree}</h3>
+                <p className="text-brand-500 dark:text-brand-400 text-sm">{edu.institution}</p>
               </div>
               <p className="text-sm text-gray-500">{edu.period}</p>
             </div>
             {edu.note && (
-              <p className="text-sm text-gray-600 mt-1 italic">{edu.note}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-600 mt-1 italic">{edu.note}</p>
             )}
           </div>
         ))}
@@ -158,21 +158,21 @@ export default function CvPage() {
 
       {/* Skills */}
       <section className="mb-12">
-        <div className="flex items-center gap-2 text-xs uppercase tracking-widest text-gray-600 mb-6">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-widest text-gray-500 dark:text-gray-600 mb-6">
           <Code2 size={14} />
           Skills
         </div>
         <div className="space-y-4">
           {Object.entries(skills).map(([category, items]) => (
             <div key={category} className="flex flex-wrap gap-x-6 gap-y-2">
-              <span className="text-sm text-gray-600 w-32 shrink-0">
+              <span className="text-sm text-gray-500 dark:text-gray-600 w-32 shrink-0">
                 {category}
               </span>
               <div className="flex flex-wrap gap-2">
                 {items.map((skill) => (
                   <span
                     key={skill}
-                    className="text-xs px-2.5 py-1 rounded-full bg-white/5 border border-white/10 text-gray-400"
+                    className="text-xs px-2.5 py-1 rounded-full bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-white/10 text-gray-600 dark:text-gray-400"
                   >
                     {skill}
                   </span>
@@ -185,7 +185,7 @@ export default function CvPage() {
 
       {/* Languages */}
       <section>
-        <div className="flex items-center gap-2 text-xs uppercase tracking-widest text-gray-600 mb-6">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-widest text-gray-500 dark:text-gray-600 mb-6">
           <Globe size={14} />
           Languages
         </div>
@@ -193,9 +193,9 @@ export default function CvPage() {
           {languages.map(({ lang, level }) => (
             <div
               key={lang}
-              className="px-4 py-2 rounded-xl bg-white/3 border border-white/5"
+              className="px-4 py-2 rounded-xl bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/5"
             >
-              <p className="text-sm font-medium text-white">{lang}</p>
+              <p className="text-sm font-medium text-gray-900 dark:text-white">{lang}</p>
               <p className="text-xs text-gray-500">{level}</p>
             </div>
           ))}

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,8 +25,19 @@
 }
 
 :root {
+  --background: #f8f8fc;
+  --foreground: #0a0a0f;
+  --nav-bg: rgba(248, 248, 252, 0.9);
+  --nav-mobile-bg: rgba(255, 255, 255, 0.97);
+  --border-subtle: rgba(0, 0, 0, 0.08);
+}
+
+.dark {
   --background: #0a0a0f;
   --foreground: #f0f0f5;
+  --nav-bg: rgba(10, 10, 15, 0.9);
+  --nav-mobile-bg: rgba(17, 17, 24, 0.97);
+  --border-subtle: rgba(255, 255, 255, 0.05);
 }
 
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import ThemeProvider from "@/components/ThemeProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -36,13 +37,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#0a0a0f] text-gray-100 min-h-screen flex flex-col`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}
+        style={{ backgroundColor: "var(--background)", color: "var(--foreground)" }}
       >
-        <Navbar />
-        <main className="flex-1 pt-16">{children}</main>
-        <Footer />
+        <ThemeProvider>
+          <Navbar />
+          <main className="flex-1 pt-16">{children}</main>
+          <Footer />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ const highlights = [
     description:
       "10+ years building distributed systems, leading engineering teams, and shipping products at scale in Berlin's tech scene.",
     href: "/cv",
-    color: "text-brand-400",
+    color: "text-brand-500 dark:text-brand-400",
     bg: "bg-brand-500/10",
     border: "border-brand-500/20",
   },
@@ -21,7 +21,7 @@ const highlights = [
     description:
       "A channel covering tech, AI, productivity, and immigration — for engineers who want depth over hype.",
     href: "/youtube",
-    color: "text-rose-400",
+    color: "text-rose-500 dark:text-rose-400",
     bg: "bg-rose-500/10",
     border: "border-rose-500/20",
   },
@@ -31,7 +31,7 @@ const highlights = [
     description:
       "Long-form technical writing on system design, engineering leadership, and building software that lasts.",
     href: "/articles",
-    color: "text-emerald-400",
+    color: "text-emerald-600 dark:text-emerald-400",
     bg: "bg-emerald-500/10",
     border: "border-emerald-500/20",
   },
@@ -41,7 +41,7 @@ const highlights = [
     description:
       "30-minute sessions for career advice, code review, or just talking shop with a senior engineer.",
     href: "/book",
-    color: "text-sky-400",
+    color: "text-sky-600 dark:text-sky-400",
     bg: "bg-sky-500/10",
     border: "border-sky-500/20",
   },
@@ -55,14 +55,14 @@ export default function HomePage() {
       {/* Hero */}
       <section className="pt-20 pb-24 md:pt-28 md:pb-32">
         <div className="max-w-3xl">
-          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-brand-500/10 border border-brand-500/20 text-brand-400 text-sm mb-6">
-            <span className="w-1.5 h-1.5 rounded-full bg-brand-400 animate-pulse" />
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-brand-500/10 border border-brand-500/20 text-brand-600 dark:text-brand-400 text-sm mb-6">
+            <span className="w-1.5 h-1.5 rounded-full bg-brand-500 dark:bg-brand-400 animate-pulse" />
             Based in Berlin · Open to new projects
           </div>
 
-          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-white leading-tight tracking-tight mb-6">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-gray-900 dark:text-white leading-tight tracking-tight mb-6">
             Hi, I&apos;m{" "}
-            <span className="bg-gradient-to-r from-brand-400 to-brand-600 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-brand-500 to-brand-700 dark:from-brand-400 dark:to-brand-600 bg-clip-text text-transparent">
               Siavash
             </span>
             .
@@ -72,12 +72,12 @@ export default function HomePage() {
             explain things.
           </h1>
 
-          <p className="text-lg sm:text-xl text-gray-400 leading-relaxed mb-8 max-w-2xl">
+          <p className="text-lg sm:text-xl text-gray-600 dark:text-gray-400 leading-relaxed mb-8 max-w-2xl">
             Principal Software Engineer & Tech Lead in Berlin. Originally from Iran.
             I run{" "}
             <Link
               href="/youtube"
-              className="text-brand-400 hover:text-brand-300 transition-colors"
+              className="text-brand-600 dark:text-brand-400 hover:text-brand-500 dark:hover:text-brand-300 transition-colors"
             >
               SiaExplains
             </Link>{" "}
@@ -94,7 +94,7 @@ export default function HomePage() {
             </Link>
             <Link
               href="/projects"
-              className="px-5 py-2.5 rounded-full border border-white/10 hover:bg-white/5 text-gray-300 font-medium transition-colors"
+              className="px-5 py-2.5 rounded-full border border-gray-300 dark:border-white/10 hover:bg-gray-100 dark:hover:bg-white/5 text-gray-700 dark:text-gray-300 font-medium transition-colors"
             >
               See my work
             </Link>
@@ -102,9 +102,9 @@ export default function HomePage() {
               href="https://youtube.com/@SiaExplains"
               target="_blank"
               rel="noopener noreferrer"
-              className="px-5 py-2.5 rounded-full border border-white/10 hover:bg-white/5 text-gray-300 font-medium transition-colors inline-flex items-center gap-2"
+              className="px-5 py-2.5 rounded-full border border-gray-300 dark:border-white/10 hover:bg-gray-100 dark:hover:bg-white/5 text-gray-700 dark:text-gray-300 font-medium transition-colors inline-flex items-center gap-2"
             >
-              <YoutubeIcon size={16} className="text-rose-400" />
+              <YoutubeIcon size={16} className="text-rose-500 dark:text-rose-400" />
               YouTube
             </a>
           </div>
@@ -113,7 +113,7 @@ export default function HomePage() {
 
       {/* Highlights */}
       <section className="pb-20">
-        <h2 className="text-sm uppercase tracking-widest text-gray-600 mb-8">
+        <h2 className="text-sm uppercase tracking-widest text-gray-500 dark:text-gray-600 mb-8">
           What I do
         </h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -121,12 +121,12 @@ export default function HomePage() {
             <Link
               key={href}
               href={href}
-              className={`group rounded-2xl border p-6 transition-all hover:border-white/20 hover:-translate-y-0.5 ${bg} ${border}`}
+              className={`group rounded-2xl border p-6 transition-all hover:border-gray-300 dark:hover:border-white/20 hover:-translate-y-0.5 ${bg} ${border}`}
             >
               <div className={`inline-flex p-2 rounded-lg ${bg} mb-4`}>
                 <Icon size={20} className={color} />
               </div>
-              <h3 className="font-semibold text-white mb-2">{title}</h3>
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-2">{title}</h3>
               <p className="text-sm text-gray-500 leading-relaxed mb-3">
                 {description}
               </p>
@@ -142,12 +142,12 @@ export default function HomePage() {
       {recentPosts.length > 0 && (
         <section className="pb-24">
           <div className="flex items-center justify-between mb-8">
-            <h2 className="text-sm uppercase tracking-widest text-gray-600">
+            <h2 className="text-sm uppercase tracking-widest text-gray-500 dark:text-gray-600">
               Recent writing
             </h2>
             <Link
               href="/blog"
-              className="text-sm text-brand-400 hover:text-brand-300 inline-flex items-center gap-1 transition-colors"
+              className="text-sm text-brand-600 dark:text-brand-400 hover:text-brand-500 dark:hover:text-brand-300 inline-flex items-center gap-1 transition-colors"
             >
               All posts <ArrowRight size={14} />
             </Link>
@@ -157,10 +157,10 @@ export default function HomePage() {
               <Link
                 key={post.slug}
                 href={`/blog/${post.slug}`}
-                className="group flex items-start justify-between gap-4 py-4 border-b border-white/5 hover:border-white/10 transition-colors"
+                className="group flex items-start justify-between gap-4 py-4 border-b border-gray-200 dark:border-white/5 hover:border-gray-300 dark:hover:border-white/10 transition-colors"
               >
                 <div>
-                  <h3 className="font-medium text-gray-200 group-hover:text-white transition-colors mb-1">
+                  <h3 className="font-medium text-gray-800 dark:text-gray-200 group-hover:text-gray-900 dark:group-hover:text-white transition-colors mb-1">
                     {post.title}
                   </h3>
                   <p className="text-sm text-gray-500 line-clamp-1">
@@ -168,8 +168,8 @@ export default function HomePage() {
                   </p>
                 </div>
                 <div className="text-right shrink-0">
-                  <p className="text-xs text-gray-600">{formatDate(post.date)}</p>
-                  <p className="text-xs text-gray-700 mt-0.5">{post.readingTime}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-600">{formatDate(post.date)}</p>
+                  <p className="text-xs text-gray-400 dark:text-gray-700 mt-0.5">{post.readingTime}</p>
                 </div>
               </Link>
             ))}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -50,21 +50,21 @@ const statusConfig = {
   live: {
     label: "Live",
     icon: Zap,
-    color: "text-emerald-400",
+    color: "text-emerald-600 dark:text-emerald-400",
     bg: "bg-emerald-500/10",
     border: "border-emerald-500/20",
   },
   building: {
     label: "Building",
     icon: Clock,
-    color: "text-amber-400",
+    color: "text-amber-600 dark:text-amber-400",
     bg: "bg-amber-500/10",
     border: "border-amber-500/20",
   },
   concept: {
     label: "Concept",
     icon: Lightbulb,
-    color: "text-sky-400",
+    color: "text-sky-600 dark:text-sky-400",
     bg: "bg-sky-500/10",
     border: "border-sky-500/20",
   },
@@ -74,11 +74,11 @@ export default function ProjectsPage() {
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div className="mb-12">
-        <p className="text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
+        <p className="text-brand-500 dark:text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
           Side projects
         </p>
-        <h1 className="text-4xl font-bold text-white mb-4">Projects</h1>
-        <p className="text-gray-400 text-lg max-w-2xl">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">Projects</h1>
+        <p className="text-gray-600 dark:text-gray-400 text-lg max-w-2xl">
           Things I&apos;m building outside of work — mostly tools I wish existed, experiments
           with new tech, and startups in progress. All built in public.
         </p>
@@ -91,7 +91,7 @@ export default function ProjectsPage() {
           return (
             <div
               key={project.title}
-              className="rounded-2xl border border-white/5 bg-white/2 p-6 hover:border-white/10 transition-colors flex flex-col"
+              className="rounded-2xl border border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-white/5 p-6 hover:border-gray-300 dark:hover:border-white/10 transition-colors flex flex-col"
             >
               <div className="flex items-start justify-between mb-4">
                 <span className="text-3xl">{project.emoji}</span>
@@ -103,10 +103,10 @@ export default function ProjectsPage() {
                 </span>
               </div>
 
-              <h3 className="font-semibold text-white text-lg mb-2">
+              <h3 className="font-semibold text-gray-900 dark:text-white text-lg mb-2">
                 {project.title}
               </h3>
-              <p className="text-sm text-gray-400 leading-relaxed flex-1 mb-4">
+              <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed flex-1 mb-4">
                 {project.description}
               </p>
 
@@ -114,7 +114,7 @@ export default function ProjectsPage() {
                 {project.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="text-xs px-2 py-0.5 rounded-full bg-white/5 text-gray-500"
+                    className="text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-white/5 text-gray-500"
                   >
                     {tag}
                   </span>
@@ -127,7 +127,7 @@ export default function ProjectsPage() {
                     href={project.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-xs text-brand-400 hover:text-brand-300 transition-colors"
+                    className="inline-flex items-center gap-1.5 text-xs text-brand-600 dark:text-brand-400 hover:text-brand-500 dark:hover:text-brand-300 transition-colors"
                   >
                     <ExternalLink size={12} />
                     Visit
@@ -138,7 +138,7 @@ export default function ProjectsPage() {
                     href={project.repo}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-300 transition-colors"
+                    className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
                   >
                     <GithubIcon size={12} />
                     Source
@@ -150,14 +150,14 @@ export default function ProjectsPage() {
         })}
       </div>
 
-      <div className="mt-12 p-6 rounded-2xl border border-dashed border-white/10 text-center">
+      <div className="mt-12 p-6 rounded-2xl border border-dashed border-gray-300 dark:border-white/10 text-center">
         <p className="text-gray-500 text-sm">
           More projects in the pipeline.{" "}
           <a
             href="https://youtube.com/@SiaExplains"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-brand-400 hover:text-brand-300 transition-colors"
+            className="text-brand-600 dark:text-brand-400 hover:text-brand-500 dark:hover:text-brand-300 transition-colors"
           >
             Follow on YouTube
           </a>{" "}

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -79,11 +79,11 @@ export default function TimelinePage() {
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div className="text-center mb-16">
-        <p className="text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
+        <p className="text-brand-500 dark:text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
           The journey
         </p>
-        <h1 className="text-4xl font-bold text-white mb-4">Timeline</h1>
-        <p className="text-gray-400 text-lg max-w-xl mx-auto">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">Timeline</h1>
+        <p className="text-gray-600 dark:text-gray-400 text-lg max-w-xl mx-auto">
           Key milestones from Tehran to Berlin — from student to Principal
           Engineer, founder, and creator.
         </p>

--- a/app/youtube/page.tsx
+++ b/app/youtube/page.tsx
@@ -13,25 +13,25 @@ const playlists = [
     title: "System Design",
     description: "Deep dives into distributed systems, architecture patterns, and real-world engineering decisions.",
     count: 8,
-    color: "bg-brand-500/10 border-brand-500/20 text-brand-400",
+    color: "bg-brand-500/10 border-brand-500/20 text-brand-600 dark:text-brand-400",
   },
   {
     title: "AI Tools for Engineers",
     description: "Honest reviews and walkthroughs of AI tools — what works, what's hype, and how to use them effectively.",
     count: 6,
-    color: "bg-emerald-500/10 border-emerald-500/20 text-emerald-400",
+    color: "bg-emerald-500/10 border-emerald-500/20 text-emerald-700 dark:text-emerald-400",
   },
   {
     title: "Immigration & International Career",
     description: "The real story of moving from Iran to Berlin through the tech industry. Visas, culture, and building a career abroad.",
     count: 5,
-    color: "bg-rose-500/10 border-rose-500/20 text-rose-400",
+    color: "bg-rose-500/10 border-rose-500/20 text-rose-600 dark:text-rose-400",
   },
   {
     title: "Engineering Productivity",
     description: "Systems, tools, and habits for engineers who want to do their best work without burning out.",
     count: 4,
-    color: "bg-sky-500/10 border-sky-500/20 text-sky-400",
+    color: "bg-sky-500/10 border-sky-500/20 text-sky-700 dark:text-sky-400",
   },
 ];
 
@@ -70,12 +70,12 @@ export default function YoutubePage() {
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       {/* Header */}
-      <div className="flex flex-col md:flex-row gap-8 items-start mb-16 pb-12 border-b border-white/5">
+      <div className="flex flex-col md:flex-row gap-8 items-start mb-16 pb-12 border-b border-gray-200 dark:border-white/5">
         <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-brand-600 to-rose-500 flex items-center justify-center shrink-0">
           <YoutubeIcon size={36} className="text-white" />
         </div>
         <div className="flex-1">
-          <h1 className="text-3xl font-bold text-white mb-2">SiaExplains</h1>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">SiaExplains</h1>
           <div className="flex flex-wrap gap-4 text-sm text-gray-500 mb-4">
             <span className="flex items-center gap-1.5">
               <Users size={14} />
@@ -86,7 +86,7 @@ export default function YoutubePage() {
               New videos bi-weekly
             </span>
           </div>
-          <p className="text-gray-400 leading-relaxed max-w-xl mb-5">
+          <p className="text-gray-600 dark:text-gray-400 leading-relaxed max-w-xl mb-5">
             A YouTube channel for engineers who want depth over hype. Covering
             system design, AI tools, engineering productivity, and the journey
             of building an international tech career.
@@ -106,7 +106,7 @@ export default function YoutubePage() {
 
       {/* Recent videos placeholder */}
       <section className="mb-14">
-        <h2 className="text-sm uppercase tracking-widest text-gray-600 mb-6">
+        <h2 className="text-sm uppercase tracking-widest text-gray-500 dark:text-gray-600 mb-6">
           Recent videos
         </h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -116,20 +116,20 @@ export default function YoutubePage() {
               href="https://youtube.com/@SiaExplains"
               target="_blank"
               rel="noopener noreferrer"
-              className="group rounded-2xl border border-white/5 bg-white/2 overflow-hidden hover:border-white/10 transition-colors"
+              className="group rounded-2xl border border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-white/5 overflow-hidden hover:border-gray-300 dark:hover:border-white/10 transition-colors"
             >
               {/* Thumbnail placeholder */}
-              <div className="aspect-video bg-gradient-to-br from-[#1a1a24] to-[#111118] flex items-center justify-center relative">
-                <Play size={32} className="text-white/20 group-hover:text-white/40 transition-colors" />
-                <span className="absolute bottom-2 right-2 text-xs bg-black/80 text-white px-1.5 py-0.5 rounded">
+              <div className="aspect-video bg-gradient-to-br from-gray-200 to-gray-100 dark:from-[#1a1a24] dark:to-[#111118] flex items-center justify-center relative">
+                <Play size={32} className="text-gray-400 dark:text-white/20 group-hover:text-gray-500 dark:group-hover:text-white/40 transition-colors" />
+                <span className="absolute bottom-2 right-2 text-xs bg-black/60 dark:bg-black/80 text-white px-1.5 py-0.5 rounded">
                   {video.duration}
                 </span>
               </div>
               <div className="p-4">
-                <h3 className="font-medium text-gray-200 group-hover:text-white transition-colors text-sm leading-snug mb-2">
+                <h3 className="font-medium text-gray-800 dark:text-gray-200 group-hover:text-gray-900 dark:group-hover:text-white transition-colors text-sm leading-snug mb-2">
                   {video.title}
                 </h3>
-                <p className="text-xs text-gray-600">
+                <p className="text-xs text-gray-500">
                   {video.views} views · {video.date}
                 </p>
               </div>
@@ -140,7 +140,7 @@ export default function YoutubePage() {
 
       {/* Playlists */}
       <section>
-        <h2 className="text-sm uppercase tracking-widest text-gray-600 mb-6">
+        <h2 className="text-sm uppercase tracking-widest text-gray-500 dark:text-gray-600 mb-6">
           Topics
         </h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -149,11 +149,11 @@ export default function YoutubePage() {
               key={pl.title}
               className={`rounded-2xl border p-5 ${pl.color}`}
             >
-              <h3 className="font-semibold text-white mb-1.5">{pl.title}</h3>
-              <p className="text-sm text-gray-400 leading-relaxed mb-3">
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-1.5">{pl.title}</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed mb-3">
                 {pl.description}
               </p>
-              <p className="text-xs text-gray-600">{pl.count} videos</p>
+              <p className="text-xs text-gray-500">{pl.count} videos</p>
             </div>
           ))}
         </div>

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -14,7 +14,7 @@ export default function ContactForm() {
           id="contact-name"
           type="text"
           placeholder="Your name"
-          className="w-full px-4 py-2.5 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-gray-600 text-sm focus:outline-none focus:border-brand-500/50 transition-colors"
+          className="w-full px-4 py-2.5 rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-600 text-sm focus:outline-none focus:border-brand-500/50 transition-colors"
         />
       </div>
       <div>
@@ -25,7 +25,7 @@ export default function ContactForm() {
           id="contact-email"
           type="email"
           placeholder="you@example.com"
-          className="w-full px-4 py-2.5 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-gray-600 text-sm focus:outline-none focus:border-brand-500/50 transition-colors"
+          className="w-full px-4 py-2.5 rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-600 text-sm focus:outline-none focus:border-brand-500/50 transition-colors"
         />
       </div>
       <div>
@@ -36,7 +36,7 @@ export default function ContactForm() {
           id="contact-message"
           rows={5}
           placeholder="What's on your mind?"
-          className="w-full px-4 py-2.5 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-gray-600 text-sm focus:outline-none focus:border-brand-500/50 transition-colors resize-none"
+          className="w-full px-4 py-2.5 rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-600 text-sm focus:outline-none focus:border-brand-500/50 transition-colors resize-none"
         />
       </div>
       <button
@@ -45,7 +45,7 @@ export default function ContactForm() {
       >
         Send message
       </button>
-      <p className="text-xs text-gray-700 text-center">
+      <p className="text-xs text-gray-400 dark:text-gray-700 text-center">
         Form not connected yet — coming soon. Or reach out directly below.
       </p>
     </form>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -20,14 +20,14 @@ export default function Footer() {
   const year = new Date().getFullYear();
 
   return (
-    <footer className="border-t border-white/5 bg-[#0a0a0f]">
+    <footer className="border-t border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-[#0a0a0f]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-10 mb-10">
           {/* Brand */}
           <div>
             <Link
               href="/"
-              className="text-white font-semibold text-lg tracking-tight"
+              className="text-gray-900 dark:text-white font-semibold text-lg tracking-tight"
             >
               <span className="text-brand-500">Sia</span>Explains
             </Link>
@@ -39,7 +39,7 @@ export default function Footer() {
 
           {/* Links */}
           <div>
-            <p className="text-xs uppercase tracking-widest text-gray-600 mb-4">
+            <p className="text-xs uppercase tracking-widest text-gray-500 dark:text-gray-600 mb-4">
               Explore
             </p>
             <ul className="space-y-2">
@@ -47,7 +47,7 @@ export default function Footer() {
                 <li key={href}>
                   <Link
                     href={href}
-                    className="text-sm text-gray-500 hover:text-white transition-colors"
+                    className="text-sm text-gray-500 hover:text-gray-900 dark:hover:text-white transition-colors"
                   >
                     {label}
                   </Link>
@@ -58,7 +58,7 @@ export default function Footer() {
 
           {/* Socials */}
           <div>
-            <p className="text-xs uppercase tracking-widest text-gray-600 mb-4">
+            <p className="text-xs uppercase tracking-widest text-gray-500 dark:text-gray-600 mb-4">
               Find me on
             </p>
             <div className="flex gap-3">
@@ -69,7 +69,7 @@ export default function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={label}
-                  className="p-2 rounded-lg text-gray-500 hover:text-white hover:bg-white/5 transition-colors"
+                  className="p-2 rounded-lg text-gray-500 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
                 >
                   <Icon size={18} />
                 </a>
@@ -78,11 +78,11 @@ export default function Footer() {
           </div>
         </div>
 
-        <div className="pt-6 border-t border-white/5 flex flex-col sm:flex-row items-center justify-between gap-2">
-          <p className="text-xs text-gray-600">
+        <div className="pt-6 border-t border-gray-200 dark:border-white/5 flex flex-col sm:flex-row items-center justify-between gap-2">
+          <p className="text-xs text-gray-500 dark:text-gray-600">
             © {year} Siavash · SiaExplains.com
           </p>
-          <p className="text-xs text-gray-700">
+          <p className="text-xs text-gray-400 dark:text-gray-700">
             Built with Next.js · Deployed on Vercel
           </p>
         </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useState, useEffect } from "react";
 import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import ThemeSwitcher from "@/components/ThemeSwitcher";
 
 const navLinks = [
   { href: "/", label: "Home" },
@@ -40,16 +41,17 @@ export default function Navbar() {
       className={cn(
         "fixed top-0 left-0 right-0 z-50 transition-all duration-300",
         scrolled
-          ? "bg-[#0a0a0f]/90 backdrop-blur-md border-b border-white/5 shadow-lg shadow-black/20"
+          ? "backdrop-blur-md border-b shadow-lg shadow-black/5 dark:shadow-black/20"
           : "bg-transparent"
       )}
+      style={scrolled ? { backgroundColor: "var(--nav-bg)", borderColor: "var(--border-subtle)" } : undefined}
     >
       <nav className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <Link
             href="/"
-            className="text-white font-semibold text-lg tracking-tight hover:text-brand-400 transition-colors"
+            className="text-gray-900 dark:text-white font-semibold text-lg tracking-tight hover:text-brand-600 dark:hover:text-brand-400 transition-colors"
           >
             <span className="text-brand-500">Sia</span>Explains
           </Link>
@@ -72,24 +74,28 @@ export default function Navbar() {
                   className={cn(
                     "px-3 py-1.5 rounded-md text-sm transition-colors",
                     pathname === href
-                      ? "text-brand-400 bg-brand-500/10"
-                      : "text-gray-400 hover:text-white hover:bg-white/5"
+                      ? "text-brand-600 dark:text-brand-400 bg-brand-500/10"
+                      : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5"
                   )}
                 >
                   {label}
                 </Link>
               )
             )}
+            <ThemeSwitcher />
           </div>
 
-          {/* Mobile hamburger */}
-          <button
-            className="lg:hidden p-2 rounded-md text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
-            onClick={() => setMenuOpen((v) => !v)}
-            aria-label="Toggle menu"
-          >
-            {menuOpen ? <X size={20} /> : <Menu size={20} />}
-          </button>
+          {/* Mobile: theme switcher + hamburger */}
+          <div className="lg:hidden flex items-center gap-1">
+            <ThemeSwitcher />
+            <button
+              className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/10 transition-colors"
+              onClick={() => setMenuOpen((v) => !v)}
+              aria-label="Toggle menu"
+            >
+              {menuOpen ? <X size={20} /> : <Menu size={20} />}
+            </button>
+          </div>
         </div>
       </nav>
 
@@ -100,7 +106,10 @@ export default function Navbar() {
           menuOpen ? "max-h-[600px] opacity-100" : "max-h-0 opacity-0"
         )}
       >
-        <div className="bg-[#111118]/95 backdrop-blur-md border-b border-white/5 px-4 py-3 space-y-1">
+        <div
+          className="backdrop-blur-md border-b px-4 py-3 space-y-1"
+          style={{ backgroundColor: "var(--nav-mobile-bg)", borderColor: "var(--border-subtle)" }}
+        >
           {navLinks.map(({ href, label, highlight }) => (
             <Link
               key={href}
@@ -110,8 +119,8 @@ export default function Navbar() {
                 highlight
                   ? "bg-brand-600 text-white font-medium text-center mt-2"
                   : pathname === href
-                  ? "text-brand-400 bg-brand-500/10"
-                  : "text-gray-400 hover:text-white hover:bg-white/5"
+                  ? "text-brand-600 dark:text-brand-400 bg-brand-500/10"
+                  : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5"
               )}
             >
               {label}

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+const ThemeContext = createContext<{
+  theme: Theme;
+  toggle: () => void;
+}>({ theme: "light", toggle: () => {} });
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as Theme | null;
+    const resolved = stored ?? "light";
+    setTheme(resolved);
+    document.documentElement.classList.toggle("dark", resolved === "dark");
+  }, []);
+
+  const toggle = () => {
+    setTheme((prev) => {
+      const next = prev === "light" ? "dark" : "light";
+      localStorage.setItem("theme", next);
+      document.documentElement.classList.toggle("dark", next === "dark");
+      return next;
+    });
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/components/ThemeSwitcher.tsx
+++ b/components/ThemeSwitcher.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Sun, Moon } from "lucide-react";
+import { useTheme } from "@/components/ThemeProvider";
+
+export default function ThemeSwitcher() {
+  const { theme, toggle } = useTheme();
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label="Toggle theme"
+      className="p-2 rounded-md transition-colors text-gray-500 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-white/10"
+    >
+      {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+    </button>
+  );
+}

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -9,34 +9,34 @@ import { TimelineEvent } from "@/types";
 const categoryConfig = {
   Education: {
     icon: GraduationCap,
-    color: "text-sky-400",
+    color: "text-sky-600 dark:text-sky-400",
     bg: "bg-sky-500/10",
     border: "border-sky-500/30",
-    dot: "bg-sky-400",
+    dot: "bg-sky-500 dark:bg-sky-400",
     glow: "shadow-sky-500/30",
   },
   Career: {
     icon: Briefcase,
-    color: "text-brand-400",
+    color: "text-brand-600 dark:text-brand-400",
     bg: "bg-brand-500/10",
     border: "border-brand-500/30",
-    dot: "bg-brand-400",
+    dot: "bg-brand-500 dark:bg-brand-400",
     glow: "shadow-brand-500/30",
   },
   Company: {
     icon: Rocket,
-    color: "text-emerald-400",
+    color: "text-emerald-600 dark:text-emerald-400",
     bg: "bg-emerald-500/10",
     border: "border-emerald-500/30",
-    dot: "bg-emerald-400",
+    dot: "bg-emerald-500 dark:bg-emerald-400",
     glow: "shadow-emerald-500/30",
   },
   Life: {
     icon: Heart,
-    color: "text-rose-400",
+    color: "text-rose-600 dark:text-rose-400",
     bg: "bg-rose-500/10",
     border: "border-rose-500/30",
-    dot: "bg-rose-400",
+    dot: "bg-rose-500 dark:bg-rose-400",
     glow: "shadow-rose-500/30",
   },
 };
@@ -81,14 +81,14 @@ function TimelineItem({
               {event.category}
             </div>
             <p className="text-xs text-gray-500 mb-1">{event.year}</p>
-            <h3 className="font-semibold text-white text-base mb-1.5">
+            <h3 className="font-semibold text-gray-900 dark:text-white text-base mb-1.5">
               {event.title}
             </h3>
-            <p className="text-sm text-gray-400 leading-relaxed">
+            <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
               {event.description}
             </p>
             {event.location && (
-              <p className="text-xs text-gray-600 mt-2">📍 {event.location}</p>
+              <p className="text-xs text-gray-500 mt-2">📍 {event.location}</p>
             )}
           </motion.div>
         )}
@@ -101,14 +101,14 @@ function TimelineItem({
           animate={inView ? { scale: 1, opacity: 1 } : {}}
           transition={{ duration: 0.4, delay: index * 0.08 + 0.1, type: "spring", stiffness: 200 }}
           className={cn(
-            "w-4 h-4 rounded-full border-2 border-[#0a0a0f] shadow-lg z-10 mt-5",
+            "w-4 h-4 rounded-full border-2 border-white dark:border-[#0a0a0f] shadow-lg z-10 mt-5",
             cfg.dot,
             cfg.glow,
             "shadow-[0_0_12px_2px]"
           )}
         />
         {!isLast && (
-          <div className="w-px flex-1 bg-gradient-to-b from-white/10 to-transparent min-h-[60px]" />
+          <div className="w-px flex-1 bg-gradient-to-b from-gray-300/60 dark:from-white/10 to-transparent min-h-[60px]" />
         )}
       </div>
 
@@ -135,14 +135,14 @@ function TimelineItem({
               {event.category}
             </div>
             <p className="text-xs text-gray-500 mb-1">{event.year}</p>
-            <h3 className="font-semibold text-white text-base mb-1.5">
+            <h3 className="font-semibold text-gray-900 dark:text-white text-base mb-1.5">
               {event.title}
             </h3>
-            <p className="text-sm text-gray-400 leading-relaxed">
+            <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
               {event.description}
             </p>
             {event.location && (
-              <p className="text-xs text-gray-600 mt-2">📍 {event.location}</p>
+              <p className="text-xs text-gray-500 mt-2">📍 {event.location}</p>
             )}
           </motion.div>
         )}
@@ -169,14 +169,14 @@ function TimelineItem({
           {event.category}
         </div>
         <p className="text-xs text-gray-500 mb-0.5">{event.year}</p>
-        <h3 className="font-semibold text-white text-sm mb-1">
+        <h3 className="font-semibold text-gray-900 dark:text-white text-sm mb-1">
           {event.title}
         </h3>
-        <p className="text-xs text-gray-400 leading-relaxed">
+        <p className="text-xs text-gray-600 dark:text-gray-400 leading-relaxed">
           {event.description}
         </p>
         {event.location && (
-          <p className="text-xs text-gray-600 mt-1.5">📍 {event.location}</p>
+          <p className="text-xs text-gray-500 mt-1.5">📍 {event.location}</p>
         )}
       </motion.div>
     </div>
@@ -187,7 +187,7 @@ export default function Timeline({ events }: { events: TimelineEvent[] }) {
   return (
     <div className="relative">
       {/* Vertical line (desktop) */}
-      <div className="hidden md:block absolute left-1/2 -translate-x-1/2 top-0 bottom-0 w-px bg-gradient-to-b from-transparent via-white/10 to-transparent" />
+      <div className="hidden md:block absolute left-1/2 -translate-x-1/2 top-0 bottom-0 w-px bg-gradient-to-b from-transparent via-gray-300/60 dark:via-white/10 to-transparent" />
 
       <div className="space-y-8 md:space-y-12">
         {events.map((event, i) => (


### PR DESCRIPTION
Adds a ThemeProvider (localStorage-backed, default light) and a ThemeSwitcher sun/moon toggle in the Navbar. Replaces hardcoded dark-only Tailwind classes across every page and component with proper dark: variants so both themes render correctly.