### PR TITLE
Fix light mode contrast on articles, blog, book, newsletter pages

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -33,18 +33,18 @@ export default async function ArticlePostPage({ params }: Props) {
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <Link
         href="/articles"
-        className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-300 transition-colors mb-10"
+        className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-900 dark:hover:text-gray-300 transition-colors mb-10"
       >
         <ArrowLeft size={14} />
         Back to Articles
       </Link>
 
-      <header className="mb-10 pb-8 border-b border-white/5">
+      <header className="mb-10 pb-8 border-b border-gray-200 dark:border-white/5">
         <div className="flex flex-wrap gap-1.5 mb-4">
           {frontmatter.tags.map((tag) => (
             <span
               key={tag}
-              className="inline-flex items-center gap-1 text-xs text-brand-400 bg-brand-500/10 border border-brand-500/20 px-2.5 py-0.5 rounded-full"
+              className="inline-flex items-center gap-1 text-xs text-brand-600 dark:text-brand-400 bg-brand-500/10 border border-brand-500/20 px-2.5 py-0.5 rounded-full"
             >
               <Tag size={9} />
               {tag}
@@ -52,14 +52,14 @@ export default async function ArticlePostPage({ params }: Props) {
           ))}
         </div>
 
-        <h1 className="text-3xl sm:text-4xl font-bold text-white leading-tight mb-4">
+        <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white leading-tight mb-4">
           {frontmatter.title}
         </h1>
-        <p className="text-gray-400 text-lg leading-relaxed mb-5">
+        <p className="text-gray-600 dark:text-gray-400 text-lg leading-relaxed mb-5">
           {frontmatter.description}
         </p>
 
-        <div className="flex flex-wrap gap-4 text-sm text-gray-600">
+        <div className="flex flex-wrap gap-4 text-sm text-gray-500">
           <span className="flex items-center gap-1.5">
             <Calendar size={13} />
             {formatDate(frontmatter.date)}
@@ -77,10 +77,10 @@ export default async function ArticlePostPage({ params }: Props) {
         <MdxContent source={content} />
       </article>
 
-      <div className="mt-16 pt-8 border-t border-white/5">
+      <div className="mt-16 pt-8 border-t border-gray-200 dark:border-white/5">
         <Link
           href="/articles"
-          className="inline-flex items-center gap-2 text-sm text-brand-400 hover:text-brand-300 transition-colors"
+          className="inline-flex items-center gap-2 text-sm text-brand-600 dark:text-brand-400 hover:text-brand-500 dark:hover:text-brand-300 transition-colors"
         >
           <ArrowLeft size={14} />
           All articles

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -16,11 +16,11 @@ export default function ArticlesPage() {
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div className="mb-12">
-        <p className="text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
+        <p className="text-brand-500 dark:text-brand-400 text-sm font-medium tracking-wide uppercase mb-3">
           Long-form
         </p>
-        <h1 className="text-4xl font-bold text-white mb-4">Articles</h1>
-        <p className="text-gray-400 text-lg">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">Articles</h1>
+        <p className="text-gray-600 dark:text-gray-400 text-lg">
           In-depth technical writing on system design, distributed systems,
           engineering leadership, and the craft of software. Takes more than 5
           minutes to read. Worth it.
@@ -28,7 +28,7 @@ export default function ArticlesPage() {
       </div>
 
       {articles.length === 0 ? (
-        <div className="text-center py-20 text-gray-600">
+        <div className="text-center py-20 text-gray-500">
           <BookOpen size={32} className="mx-auto mb-3 opacity-30" />
           <p>No articles yet. Check back soon.</p>
         </div>
@@ -38,32 +38,32 @@ export default function ArticlesPage() {
             <Link
               key={article.slug}
               href={`/articles/${article.slug}`}
-              className="group block rounded-2xl border border-white/5 bg-white/2 p-6 hover:border-white/10 hover:-translate-y-0.5 transition-all"
+              className="group block rounded-2xl border border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-white/5 p-6 hover:border-gray-300 dark:hover:border-white/10 hover:-translate-y-0.5 transition-all"
             >
               <div className="flex flex-wrap gap-1.5 mb-3">
                 {article.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="inline-flex items-center gap-1 text-xs text-gray-600 bg-white/3 px-2 py-0.5 rounded-full"
+                    className="inline-flex items-center gap-1 text-xs text-gray-500 bg-gray-100 dark:bg-white/5 px-2 py-0.5 rounded-full"
                   >
                     <Tag size={9} />
                     {tag}
                   </span>
                 ))}
               </div>
-              <h2 className="text-xl font-semibold text-gray-100 group-hover:text-white transition-colors mb-2">
+              <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-100 group-hover:text-gray-900 dark:group-hover:text-white transition-colors mb-2">
                 {article.title}
               </h2>
               <p className="text-gray-500 leading-relaxed mb-4 text-sm">
                 {article.description}
               </p>
               <div className="flex items-center justify-between">
-                <div className="flex gap-3 text-xs text-gray-600">
+                <div className="flex gap-3 text-xs text-gray-500">
                   <span>{formatDate(article.date)}</span>
                   <span>·</span>
                   <span>{article.readingTime}</span>
                 </div>
-                <span className="text-xs text-brand-400 inline-flex items-center gap-1 group-hover:gap-2 transition-all">
+                <span className="text-xs text-brand-600 dark:text-brand-400 inline-flex items-center gap-1 group-hover:gap-2 transition-all">
                   Read article <ArrowRight size={12} />
                 </span>
               </div>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -33,18 +33,18 @@ export default async function BlogPostPage({ params }: Props) {
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <Link
         href="/blog"
-        className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-300 transition-colors mb-10"
+        className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-900 dark:hover:text-gray-300 transition-colors mb-10"
       >
         <ArrowLeft size={14} />
         Back to Blog
       </Link>
 
-      <header className="mb-10 pb-8 border-b border-white/5">
+      <header className="mb-10 pb-8 border-b border-gray-200 dark:border-white/5">
         <div className="flex flex-wrap gap-1.5 mb-4">
           {frontmatter.tags.map((tag) => (
             <span
               key={tag}
-              className="inline-flex items-center gap-1 text-xs text-brand-400 bg-brand-500/10 border border-brand-500/20 px-2.5 py-0.5 rounded-full"
+              className="inline-flex items-center gap-1 text-xs text-brand-600 dark:text-brand-400 bg-brand-500/10 border border-brand-500/20 px-2.5 py-0.5 rounded-full"
             >
               <Tag size={9} />
               {tag}
@@ -52,14 +52,14 @@ export default async function BlogPostPage({ params }: Props) {
           ))}
         </div>
 
-        <h1 className="text-3xl sm:text-4xl font-bold text-white leading-tight mb-4">
+        <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white leading-tight mb-4">
           {frontmatter.title}
         </h1>
-        <p className="text-gray-400 text-lg leading-relaxed mb-5">
+        <p className="text-gray-600 dark:text-gray-400 text-lg leading-relaxed mb-5">
           {frontmatter.description}
         </p>
 
-        <div className="flex flex-wrap gap-4 text-sm text-gray-600">
+        <div className="flex flex-wrap gap-4 text-sm text-gray-500">
           <span className="flex items-center gap-1.5">
             <Calendar size={13} />
             {formatDate(frontmatter.date)}
@@ -77,10 +77,10 @@ export default async function BlogPostPage({ params }: Props) {
         <MdxContent source={content} />
       </article>
 
-      <div className="mt-16 pt-8 border-t border-white/5">
+      <div className="mt-16 pt-8 border-t border-gray-200 dark:border-white/5">
         <Link
           href="/blog"
-          className="inline-flex items-center gap-2 text-sm text-brand-400 hover:text-brand-300 transition-colors"
+          className="inline-flex items-center gap-2 text-sm text-brand-600 dark:text-brand-400 hover:text-brand-500 dark:hover:text-brand-300 transition-colors"
         >
           <ArrowLeft size={14} />
           All blog posts

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -14,7 +14,7 @@ const sessionTypes = [
     duration: "30 min",
     description:
       "Career decisions, international job search, transitioning to senior/principal roles, or navigating immigration through tech.",
-    color: "text-brand-400",
+    color: "text-brand-600 dark:text-brand-400",
     bg: "bg-brand-500/10",
     border: "border-brand-500/20",
   },
@@ -24,7 +24,7 @@ const sessionTypes = [
     duration: "45 min",
     description:
       "Walk me through your system design, codebase, or architecture decisions. I'll give honest, senior-level feedback.",
-    color: "text-emerald-400",
+    color: "text-emerald-600 dark:text-emerald-400",
     bg: "bg-emerald-500/10",
     border: "border-emerald-500/20",
   },
@@ -34,7 +34,7 @@ const sessionTypes = [
     duration: "30 min",
     description:
       "No agenda required. Come with questions, problems, or ideas. Good for a second opinion on anything technical.",
-    color: "text-sky-400",
+    color: "text-sky-600 dark:text-sky-400",
     bg: "bg-sky-500/10",
     border: "border-sky-500/20",
   },
@@ -45,10 +45,10 @@ export default function BookPage() {
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div className="text-center mb-12">
         <div className="inline-flex p-4 rounded-2xl bg-brand-500/10 border border-brand-500/20 mb-6">
-          <Calendar size={28} className="text-brand-400" />
+          <Calendar size={28} className="text-brand-600 dark:text-brand-400" />
         </div>
-        <h1 className="text-4xl font-bold text-white mb-4">Book a Call</h1>
-        <p className="text-gray-400 text-lg leading-relaxed max-w-xl mx-auto">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">Book a Call</h1>
+        <p className="text-gray-600 dark:text-gray-400 text-lg leading-relaxed max-w-xl mx-auto">
           I set aside time each week for 1:1 sessions. Whether you&apos;re navigating
           a career decision, building something interesting, or just want a fresh
           set of eyes — let&apos;s talk.
@@ -68,12 +68,12 @@ export default function BookPage() {
               </div>
               <div className="flex-1">
                 <div className="flex items-center justify-between gap-2 mb-1">
-                  <h3 className="font-semibold text-white">{title}</h3>
+                  <h3 className="font-semibold text-gray-900 dark:text-white">{title}</h3>
                   <span className={`text-xs font-medium ${color}`}>
                     {duration}
                   </span>
                 </div>
-                <p className="text-sm text-gray-400 leading-relaxed">
+                <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
                   {description}
                 </p>
               </div>
@@ -83,19 +83,19 @@ export default function BookPage() {
       </div>
 
       {/* Calendly placeholder */}
-      <div className="rounded-2xl border border-white/5 bg-white/2 overflow-hidden">
-        <div className="p-6 border-b border-white/5">
-          <h2 className="font-semibold text-white mb-1">Pick a time</h2>
+      <div className="rounded-2xl border border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-white/5 overflow-hidden">
+        <div className="p-6 border-b border-gray-200 dark:border-white/5">
+          <h2 className="font-semibold text-gray-900 dark:text-white mb-1">Pick a time</h2>
           <p className="text-sm text-gray-500">
             All sessions are conducted via Google Meet or Zoom.
           </p>
         </div>
 
         {/* Calendly embed placeholder */}
-        <div className="aspect-[4/3] flex flex-col items-center justify-center bg-[#111118] p-8 text-center">
-          <Calendar size={40} className="text-gray-700 mb-4" />
+        <div className="aspect-[4/3] flex flex-col items-center justify-center bg-gray-100 dark:bg-[#111118] p-8 text-center">
+          <Calendar size={40} className="text-gray-400 dark:text-gray-700 mb-4" />
           <p className="text-gray-500 text-sm mb-2">Calendly booking widget</p>
-          <p className="text-gray-700 text-xs max-w-xs">
+          <p className="text-gray-400 dark:text-gray-700 text-xs max-w-xs">
             Calendly embed will appear here once configured. In the meantime,
             reach out via email or LinkedIn to schedule.
           </p>
@@ -108,7 +108,7 @@ export default function BookPage() {
         </div>
       </div>
 
-      <div className="mt-8 p-5 rounded-xl border border-white/5 text-sm text-gray-500 space-y-1.5">
+      <div className="mt-8 p-5 rounded-xl border border-gray-200 dark:border-white/5 text-sm text-gray-500 space-y-1.5">
         <p>⏰ Sessions run in CET (Berlin time). I accommodate other timezones when possible.</p>
         <p>🎥 All sessions are confidential — I don&apos;t record without permission.</p>
         <p>💬 Please come prepared with a specific question or topic to make the most of our time.</p>

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -36,10 +36,10 @@ export default function NewsletterPage() {
     <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div className="text-center mb-12">
         <div className="inline-flex p-4 rounded-2xl bg-brand-500/10 border border-brand-500/20 mb-6">
-          <Mail size={28} className="text-brand-400" />
+          <Mail size={28} className="text-brand-600 dark:text-brand-400" />
         </div>
-        <h1 className="text-4xl font-bold text-white mb-4">The Newsletter</h1>
-        <p className="text-gray-400 text-lg leading-relaxed">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">The Newsletter</h1>
+        <p className="text-gray-600 dark:text-gray-400 text-lg leading-relaxed">
           A newsletter for engineers who want to think more clearly about
           software, career, and the future of tech. Written by Siavash from
           Berlin, twice a month.
@@ -51,10 +51,10 @@ export default function NewsletterPage() {
         {perks.map(({ icon: Icon, title, description }) => (
           <div
             key={title}
-            className="rounded-xl border border-white/5 bg-white/2 p-4"
+            className="rounded-xl border border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-white/5 p-4"
           >
-            <Icon size={16} className="text-brand-400 mb-2" />
-            <h3 className="font-medium text-white text-sm mb-1">{title}</h3>
+            <Icon size={16} className="text-brand-600 dark:text-brand-400 mb-2" />
+            <h3 className="font-medium text-gray-900 dark:text-white text-sm mb-1">{title}</h3>
             <p className="text-xs text-gray-500 leading-relaxed">{description}</p>
           </div>
         ))}

--- a/components/MdxContent.tsx
+++ b/components/MdxContent.tsx
@@ -2,71 +2,71 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 
 const components = {
   h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-    <h1 className="text-3xl font-bold text-white mt-8 mb-4" {...props} />
+    <h1 className="text-3xl font-bold text-gray-900 dark:text-white mt-8 mb-4" {...props} />
   ),
   h2: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-    <h2 className="text-2xl font-semibold text-white mt-8 mb-3" {...props} />
+    <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mt-8 mb-3" {...props} />
   ),
   h3: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-    <h3 className="text-xl font-semibold text-white mt-6 mb-2" {...props} />
+    <h3 className="text-xl font-semibold text-gray-900 dark:text-white mt-6 mb-2" {...props} />
   ),
   p: (props: React.HTMLAttributes<HTMLParagraphElement>) => (
-    <p className="text-gray-300 leading-relaxed mb-4" {...props} />
+    <p className="text-gray-700 dark:text-gray-300 leading-relaxed mb-4" {...props} />
   ),
   a: (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
     <a
-      className="text-brand-400 hover:text-brand-300 underline underline-offset-2 transition-colors"
+      className="text-brand-600 dark:text-brand-400 hover:text-brand-500 dark:hover:text-brand-300 underline underline-offset-2 transition-colors"
       {...props}
     />
   ),
   code: (props: React.HTMLAttributes<HTMLElement>) => (
     <code
-      className="bg-white/5 text-brand-300 px-1.5 py-0.5 rounded text-sm font-mono"
+      className="bg-gray-100 dark:bg-white/5 text-brand-600 dark:text-brand-300 px-1.5 py-0.5 rounded text-sm font-mono"
       {...props}
     />
   ),
   pre: (props: React.HTMLAttributes<HTMLPreElement>) => (
     <pre
-      className="bg-[#111118] border border-white/10 rounded-xl p-4 overflow-x-auto my-6 text-sm"
+      className="bg-gray-100 dark:bg-[#111118] border border-gray-200 dark:border-white/10 rounded-xl p-4 overflow-x-auto my-6 text-sm"
       {...props}
     />
   ),
   blockquote: (props: React.HTMLAttributes<HTMLQuoteElement>) => (
     <blockquote
-      className="border-l-4 border-brand-500/50 pl-4 my-4 text-gray-400 italic"
+      className="border-l-4 border-brand-500/50 pl-4 my-4 text-gray-600 dark:text-gray-400 italic"
       {...props}
     />
   ),
   ul: (props: React.HTMLAttributes<HTMLUListElement>) => (
     <ul
-      className="list-disc list-inside text-gray-300 space-y-1.5 mb-4"
+      className="list-disc list-inside text-gray-700 dark:text-gray-300 space-y-1.5 mb-4"
       {...props}
     />
   ),
   ol: (props: React.HTMLAttributes<HTMLOListElement>) => (
     <ol
-      className="list-decimal list-inside text-gray-300 space-y-1.5 mb-4"
+      className="list-decimal list-inside text-gray-700 dark:text-gray-300 space-y-1.5 mb-4"
       {...props}
     />
   ),
-  hr: () => <hr className="border-white/10 my-8" />,
+  hr: () => <hr className="border-gray-200 dark:border-white/10 my-8" />,
   table: (props: React.HTMLAttributes<HTMLTableElement>) => (
     <div className="overflow-x-auto my-6">
       <table
-        className="w-full text-sm border-collapse border border-white/10"
+        className="w-full text-sm border-collapse border border-gray-200 dark:border-white/10"
         {...props}
       />
     </div>
   ),
   th: (props: React.HTMLAttributes<HTMLTableCellElement>) => (
     <th
-      className="border border-white/10 px-3 py-2 text-left text-white font-semibold bg-white/5"
+      className="border border-gray-200 dark:border-white/10 px-3 py-2 text-left text-gray-900 dark:text-white font-semibold bg-gray-50 dark:bg-white/5"
       {...props}
     />
   ),
   td: (props: React.HTMLAttributes<HTMLTableCellElement>) => (
     <td
-      className="border border-white/10 px-3 py-2 text-gray-400"
+      className="border border-gray-200 dark:border-white/10 px-3 py-2 text-gray-600 dark:text-gray-400"
       {...props}
     />
   ),

--- a/components/NewsletterForm.tsx
+++ b/components/NewsletterForm.tsx
@@ -2,8 +2,8 @@
 
 export default function NewsletterForm() {
   return (
-    <div className="rounded-2xl border border-white/5 bg-white/2 p-8">
-      <h2 className="text-xl font-semibold text-white mb-2">
+    <div className="rounded-2xl border border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-white/5 p-8">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
         Join the newsletter
       </h2>
       <p className="text-sm text-gray-500 mb-6">
@@ -19,7 +19,7 @@ export default function NewsletterForm() {
             id="nl-name"
             type="text"
             placeholder="Siavash"
-            className="w-full px-4 py-2.5 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-gray-600 text-sm focus:outline-none focus:border-brand-500/50 transition-colors"
+            className="w-full px-4 py-2.5 rounded-lg bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-600 text-sm focus:outline-none focus:border-brand-500/50 transition-colors"
           />
         </div>
         <div>
@@ -30,7 +30,7 @@ export default function NewsletterForm() {
             id="nl-email"
             type="email"
             placeholder="you@example.com"
-            className="w-full px-4 py-2.5 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-gray-600 text-sm focus:outline-none focus:border-brand-500/50 transition-colors"
+            className="w-full px-4 py-2.5 rounded-lg bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-600 text-sm focus:outline-none focus:border-brand-500/50 transition-colors"
           />
         </div>
         <button
@@ -41,7 +41,7 @@ export default function NewsletterForm() {
         </button>
       </form>
 
-      <p className="text-xs text-gray-700 text-center mt-4">
+      <p className="text-xs text-gray-400 dark:text-gray-700 text-center mt-4">
         Newsletter service not connected yet. Coming soon.
       </p>
     </div>


### PR DESCRIPTION
Missed in previous pass: articles list, article/blog post slug pages, MdxContent MDX renderer, book, newsletter and NewsletterForm all had hardcoded dark-only classes. Replaced with dark: variants for proper contrast in both themes.