### PR TITLE
Profile & Content Updates: social links, WikiDigit, Emojar, German B2, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,50 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Hey, I'm Siavash 👋
 
-## Getting Started
+Principal Software Engineer and Tech Lead based in Berlin. Originally from Iran — been writing code professionally since 2007, which feels like both forever and yesterday at the same time.
 
-First, run the development server:
+I run **[SiaExplains](https://siaexplains.com)** — a YouTube channel, blog, and collection of side projects where I share what I've learned about engineering, AI, career growth, and navigating the tech world as an international professional.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+---
+
+## What I'm up to
+
+- 🏢 Leading engineering at **MHP** in Berlin — working on tooling for Volkswagen Group
+- 📺 Creating content on **[YouTube @SiaExplains](https://youtube.com/@SiaExplains)** about tech, AI, and engineering careers
+- 🫙 Running **[Emojar.com](https://emojar.com)** — an emoji search and copy tool (built entirely with AI, zero lines of hand-written code)
+- 📰 Building **[WikiDigit.com](https://wikidigit.com)** — a tech media and news site for engineers who want signal over noise
+- ✍️ Writing about system design, AI tools, and the realities of a software career at [siaexplains.com/blog](https://siaexplains.com/blog)
+
+---
+
+## This repo
+
+This is the source code for **siaexplains.com** — my personal site, built with:
+
+- **Next.js 15** (App Router)
+- **TypeScript**
+- **Tailwind CSS v4**
+- **MDX** for blog posts and articles
+
+It's open source. Feel free to look around, take inspiration, or open an issue if something is broken.
+
+---
+
+## Tech I work with
+
+```
+ReactJS · Next.js · Node.js · TypeScript · AWS · PostgreSQL
+MongoDB · GraphQL · Docker · Terraform · Python
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+---
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Find me
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- 🌐 [siaexplains.com](https://siaexplains.com)
+- 💼 [LinkedIn](https://www.linkedin.com/in/siavash-ghanbari/)
+- 🐙 [GitHub @SiaExplains](https://github.com/SiaExplains)
+- 📺 [YouTube @SiaExplains](https://youtube.com/@SiaExplains)
 
-## Learn More
+---
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+*Iran → Sydney → Berlin. Loving the journey.*

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -100,7 +100,7 @@ export default function BookPage() {
             reach out via email or LinkedIn to schedule.
           </p>
           <a
-            href="mailto:siavash@siaexplains.com?subject=Book a Call"
+            href="mailto:siaexplains@gmail.com?subject=Book a Call"
             className="mt-5 px-5 py-2.5 rounded-full bg-brand-600 hover:bg-brand-500 text-white font-medium text-sm transition-colors"
           >
             Email to schedule

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -99,7 +99,7 @@ export default function ContactPage() {
               <Mail size={14} className="text-brand-500 dark:text-brand-400" />
               <span className="text-sm font-medium text-gray-900 dark:text-white">Email</span>
             </div>
-            <p className="text-sm text-gray-500">siavash@siaexplains.com</p>
+            <p className="text-sm text-gray-500">siaexplains@gmail.com</p>
           </div>
         </div>
       </div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -20,8 +20,8 @@ const socials = [
   },
   {
     label: "GitHub",
-    handle: "github.com/siavash",
-    href: "https://github.com/siavash",
+    handle: "github.com/SiaExplains",
+    href: "https://github.com/SiaExplains",
     icon: GithubIcon,
     color: "text-gray-600 dark:text-gray-300",
     bg: "bg-gray-100 dark:bg-white/5",
@@ -29,8 +29,8 @@ const socials = [
   },
   {
     label: "LinkedIn",
-    handle: "linkedin.com/in/siavash",
-    href: "https://linkedin.com/in/siavash",
+    handle: "linkedin.com/in/siavash-ghanbari",
+    href: "https://www.linkedin.com/in/siavash-ghanbari/",
     icon: LinkedinIcon,
     color: "text-sky-600 dark:text-sky-400",
     bg: "bg-sky-500/10",

--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -150,7 +150,7 @@ const skills = {
 
 const languages = [
   { lang: "English", level: "Fluent" },
-  { lang: "German", level: "A2" },
+  { lang: "German", level: "B2" },
   { lang: "Persian", level: "Native" },
 ];
 

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { ExternalLink, Zap, Clock, Lightbulb } from "lucide-react";
+import { ExternalLink, Zap, Clock, Lightbulb, CalendarDays } from "lucide-react";
 import { GithubIcon } from "@/components/SocialIcons";
 import { Project } from "@/types";
 
@@ -9,15 +9,26 @@ export const metadata: Metadata = {
   description: "Side projects and startup ideas by Siavash — built in public.",
 };
 
-const projects: (Project & { emoji?: string; image?: string })[] = [
+const projects: (Project & { emoji?: string; image?: string; started?: string })[] = [
+  {
+    emoji: "📰",
+    title: "WikiDigit",
+    description:
+      "A tech media and news website covering the latest in technology, AI, and the digital world. Curated content for engineers and tech enthusiasts who want signal over noise.",
+    tags: ["Next.js", "TypeScript", "Tailwind", "CMS"],
+    status: "live",
+    url: "https://wikidigit.com",
+    started: "Jan 2026",
+  },
   {
     image: "/emojar-favicon.png",
     title: "Emojar",
     description:
-      "A free online emoji platform where users can easily search, copy, and paste emojis into social media, messages, and documents.",
-    tags: ["TypeScript", "Next.js", "Tailwind"],
+      "A free emoji search and copy platform with 3,600+ emojis, curated collections, and mini-games. Built entirely with AI tools — zero lines of hand-written code. Monetised via Google Ads.",
+    tags: ["TypeScript", "Next.js", "Tailwind", "Google Ads"],
     status: "live",
     url: "https://emojar.com",
+    started: "Apr 2025",
   },
   {
     emoji: "🌐",
@@ -27,7 +38,7 @@ const projects: (Project & { emoji?: string; image?: string })[] = [
     tags: ["Next.js", "TypeScript", "Tailwind", "MDX", "Neon"],
     status: "live",
     url: "https://siaexplains.com",
-    repo: "https://github.com/siavash/siaexplains",
+    repo: "https://github.com/SiaExplains/SiaExplains",
   },
   {
     emoji: "🤖",
@@ -36,7 +47,7 @@ const projects: (Project & { emoji?: string; image?: string })[] = [
       "A GitHub app that performs automated code reviews using LLMs. Catches security issues, performance anti-patterns, and style violations before human review.",
     tags: ["TypeScript", "Claude API", "GitHub API", "PostgreSQL"],
     status: "building",
-    repo: "https://github.com/siavash/ai-review-bot",
+    repo: "https://github.com/SiaExplains/ai-review-bot",
   },
   {
     emoji: "📊",
@@ -141,28 +152,36 @@ export default function ProjectsPage() {
                 ))}
               </div>
 
-              <div className="flex gap-3">
-                {project.url && (
-                  <a
-                    href={project.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-xs text-brand-600 dark:text-brand-400 hover:text-brand-500 dark:hover:text-brand-300 transition-colors"
-                  >
-                    <ExternalLink size={12} />
-                    Visit
-                  </a>
-                )}
-                {project.repo && (
-                  <a
-                    href={project.repo}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
-                  >
-                    <GithubIcon size={12} />
-                    Source
-                  </a>
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex gap-3">
+                  {project.url && (
+                    <a
+                      href={project.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-xs text-brand-600 dark:text-brand-400 hover:text-brand-500 dark:hover:text-brand-300 transition-colors"
+                    >
+                      <ExternalLink size={12} />
+                      Visit
+                    </a>
+                  )}
+                  {project.repo && (
+                    <a
+                      href={project.repo}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+                    >
+                      <GithubIcon size={12} />
+                      Source
+                    </a>
+                  )}
+                </div>
+                {project.started && (
+                  <span className="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-600">
+                    <CalendarDays size={10} />
+                    {project.started}
+                  </span>
                 )}
               </div>
             </div>

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -18,6 +18,22 @@ const timelineEvents: TimelineEvent[] = [
     location: "Berlin, Germany",
   },
   {
+    year: "2026",
+    title: "Launched WikiDigit",
+    category: "Company",
+    description:
+      "Founded WikiDigit — a tech media and news platform delivering curated stories on AI, software, and the digital world. Built for engineers and tech enthusiasts who want depth over clickbait.",
+    location: "Berlin, Germany",
+  },
+  {
+    year: "2025",
+    title: "Launched Emojar",
+    category: "Company",
+    description:
+      "Built and launched Emojar.com — a free emoji search and copy platform featuring 3,600+ emojis, curated collections, and mini-games. The entire product was shipped using AI tools with zero hand-written code. Monetised via Google Ads.",
+    location: "Berlin, Germany",
+  },
+  {
     year: "2023",
     title: "Principal Engineer & Manager at MHP",
     category: "Career",

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,8 +3,8 @@ import { YoutubeIcon, GithubIcon, LinkedinIcon, TwitterIcon } from "@/components
 
 const socials = [
   { label: "YouTube", href: "https://youtube.com/@SiaExplains", icon: YoutubeIcon },
-  { label: "GitHub", href: "https://github.com/siavash", icon: GithubIcon },
-  { label: "LinkedIn", href: "https://linkedin.com/in/siavash", icon: LinkedinIcon },
+  { label: "GitHub", href: "https://github.com/SiaExplains", icon: GithubIcon },
+  { label: "LinkedIn", href: "https://www.linkedin.com/in/siavash-ghanbari/", icon: LinkedinIcon },
   { label: "Twitter", href: "https://twitter.com/SiaExplains", icon: TwitterIcon },
 ];
 

--- a/content/blog/i-launched-wikidigit.mdx
+++ b/content/blog/i-launched-wikidigit.mdx
@@ -1,0 +1,98 @@
+---
+title: "I Launched a Tech Media Site. Here's Why — And What I Learned."
+date: "2026-05-18"
+description: "WikiDigit is my attempt at a tech news site that actually respects your intelligence. Here's the story of why I built it, how it runs, and what launching a media brand taught me in 2026."
+tags: ["side-project", "build-in-public", "ai", "media"]
+slug: "i-launched-wikidigit"
+---
+
+# I Launched a Tech Media Site. Here's Why — And What I Learned.
+
+I'm not a journalist. I'm a software engineer.
+
+But somewhere between reading my fourth breathless AI hype article of the morning and quietly closing the tab in frustration, I thought: *someone should build a tech news site that treats engineers like adults.*
+
+So I built one. Meet **[WikiDigit.com](https://wikidigit.com)**.
+
+---
+
+## The Problem I Was Trying to Solve
+
+Tech news in 2026 is everywhere and mostly useless.
+
+You've got the clickbait farms — everything is either *revolutionary* or *catastrophic*, nothing in between. You've got the press-release republishers — a startup raises money, every outlet runs the same 200-word summary with zero analysis. And you've got the algorithm-optimised content machines, writing for search rankings instead of for you.
+
+What I couldn't find was a publication that covered AI, startups, dev tools, security, and science with the same rigour I'd expect from a good engineering design document. Direct, specific, consequential.
+
+That's the gap WikiDigit is trying to fill.
+
+> *"Tech news for the curious"* — that's the editorial line. Curious people don't want to be told what to think. They want context, stakes, and enough signal to form their own view.
+
+---
+
+## What WikiDigit Actually Covers
+
+Six categories, each chosen deliberately:
+
+- **AI** — not every new model release, but the ones that actually shift something
+- **Startups** — funding rounds with context, not just the numbers
+- **Dev Tools** — the stuff engineers actually use (or should know about)
+- **Security** — breaches, vulnerabilities, and the policy landscape around them
+- **Science** — the research that eventually becomes the tech
+- **Business** — the industry dynamics, acquisitions, and legal battles shaping the field
+
+The editorial filter is simple: *does this matter?* Not "is this new" — new things happen constantly. But does this actually change something for someone building, investing, or working in tech?
+
+---
+
+## How I Built It
+
+I'll be honest: WikiDigit was partly an experiment.
+
+After building [Emojar](/blog/i-built-emojar-with-zero-lines-of-code) — a complete product with zero hand-written code — I wanted to test whether the same approach could work for something more content-heavy. A publication, not just a utility.
+
+The answer is: mostly yes, with some important caveats.
+
+**What AI tools handled well:**
+- Site structure, design, and front-end components
+- SEO foundations — meta tags, sitemap, structured data
+- The publishing workflow scaffolding
+
+**What still required editorial judgement:**
+- Deciding *what* to cover
+- Writing and editing that doesn't sound like a press release
+- Building an editorial voice that's consistent across contributors
+
+The second list is the harder one. You can automate the infrastructure of a publication fairly easily in 2026. The editorial layer — the taste, the framing, the *why this matters* — that's still human work. At least for now.
+
+---
+
+## What I Learned About Running a Media Brand
+
+A few things I didn't expect going in:
+
+**Distribution is the real product.** Publishing a great article that nobody reads doesn't move the needle. Building an audience is a separate discipline from building a publication, and it doesn't come for free just because the content is good.
+
+**Consistency beats quality at the start.** The instinct as an engineer is to optimise every piece before shipping it. That's the wrong instinct for media. Showing up regularly matters more early on than any individual piece being perfect.
+
+**The editorial line is a commitment.** Saying "we cover what matters" sounds simple. But it means turning down easy content — a big name raises money, everyone covers it, but if there's nothing meaningful to say about it, we don't run it. That discipline is harder to maintain than it sounds.
+
+---
+
+## Where WikiDigit Is Now
+
+WikiDigit launched in January 2026 and is a genuine side project — running alongside my day job and the rest of what I build.
+
+It's live, it's publishing regularly, and the editorial focus is sharp. The audience is growing, slowly and organically, which is exactly how I want it. I'm not chasing virality. I'm trying to build something that a specific type of reader — the engineer who wants context, not noise — finds genuinely useful.
+
+If that sounds like you: **[wikidigit.com](https://wikidigit.com)**.
+
+---
+
+## The Honest Take
+
+Building WikiDigit taught me something I didn't fully appreciate from the software side: *distribution is the hard part of media, the same way product-market fit is the hard part of software.* The technical execution is solvable. The actual value — the editorial angle, the audience relationship, the trust — takes time.
+
+I'm patient. I've been building things since 2007. Some of them take a while.
+
+This one will too. And that's fine.


### PR DESCRIPTION
## Summary

A batch of profile accuracy, content, and email updates across the site.

| # | Change | File(s) |
|---|---|---|
| 1.1 | Fix LinkedIn URL → `linkedin.com/in/siavash-ghanbari/` | `Footer.tsx`, `contact/page.tsx` |
| 1.2 | Fix GitHub URL → `github.com/SiaExplains` | `Footer.tsx`, `contact/page.tsx`, `projects/page.tsx` |
| 1.3 | Update German language level A2 → **B2** | `cv/page.tsx` |
| 1.4 | Add **WikiDigit** (Jan 2026) to Projects & Timeline | `projects/page.tsx`, `timeline/page.tsx` |
| 1.5 | Rewrite `README.md` as a personal GitHub profile README | `README.md` |
| 1.6 | Add **Emojar** (Apr 2025) to Timeline; enrich Projects card | `projects/page.tsx`, `timeline/page.tsx` |
| + | Fix email → `siaexplains@gmail.com` (Contact + Book pages) | `contact/page.tsx`, `book/page.tsx` |
| + | New blog post: **WikiDigit** side project story | `content/blog/i-launched-wikidigit.mdx` |

## Details

**Social links** — Footer and Contact now point to the correct full URLs for LinkedIn and GitHub.

**German B2** — updated in the CV languages section.

**WikiDigit** — added as a `live` project card (tech media & news, wikidigit.com, Jan 2026) with a timeline entry. Also has a dedicated blog post covering the editorial mission, how it was built, and lessons from running a media brand.

**Emojar** — description enriched with Google Ads context and zero-code origin story. A `started` date badge now renders on project cards. Added as a `Company` timeline event (Apr 2025).

**Email** — `siavash@siaexplains.com` replaced with `siaexplains@gmail.com` on Contact and Book pages (CV already had the correct address).

**README** — rewritten from Next.js boilerplate into a personal GitHub profile README written from Siavash's voice.

## Test plan

- [ ] `/` — footer shows correct GitHub & LinkedIn URLs
- [ ] `/contact` — GitHub/LinkedIn cards correct; email shows `siaexplains@gmail.com`
- [ ] `/book` — mailto link uses `siaexplains@gmail.com`
- [ ] `/cv` — German shows **B2**
- [ ] `/projects` — WikiDigit card appears (live, Jan 2026); Emojar card enriched; start date badges visible
- [ ] `/timeline` — WikiDigit (2026) and Emojar (2025) events present
- [ ] `/blog` — WikiDigit post appears in listing
- [ ] `/blog/i-launched-wikidigit` — post renders correctly
- [ ] `README.md` preview on GitHub looks correct
- [ ] No ESLint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)